### PR TITLE
chore: add standard automation workflows

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,22 @@
+name: Documentation Sync
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - 'README*'
+      - 'CHANGELOG*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  docs-sync:
+    uses: jclee941/.github/.github/workflows/reusable-docs-sync.yml@master
+    secrets: inherit

--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -1,0 +1,18 @@
+name: Issue Management
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  issues:
+    types: [opened, edited, closed, reopened, labeled, unlabeled, assigned]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  issue-management:
+    uses: jclee941/.github/.github/workflows/reusable-issue-management.yml@master
+    secrets: inherit

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,14 @@
+name: PR Checks
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  pr-checks:
+    uses: jclee941/.github/.github/workflows/reusable-pr-checks.yml@master
+    secrets: inherit


### PR DESCRIPTION
## Summary
- add standardized automation workflows from github-bot
- includes PR checks, issue management, and docs sync
- targets the self-hosted homelab runner configuration