### PR TITLE
feat(llm): provider-level api_base fallback for CLIProxyAPI outages

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -31,6 +31,12 @@ response_language = "ko"
 # FORK: CLIProxyAPI endpoint via Docker internal network
 # The api_key is NOT set here; use env var OPENAI_KEY from GitHub Secrets or .env
 api_base = "https://cliproxy.jclee.me/v1"
+# FORK: provider-level fallback. If the primary api_base is unreachable
+# (connection refused / Cloudflare 524 / timeout), each model is retried
+# against these base URLs in order before moving to the next model.
+# Empty list = no provider fallback (original behavior). The fallback bases
+# must serve the same OpenAI-compatible API and accept the same api_key.
+api_base_fallbacks = []
 
 # ---------------------------------------------------------------------------
 # [litellm] — Parameter Handling

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -470,8 +470,45 @@ class LiteLLMAIHandler(BaseAiHandler):
 
     async def _get_completion(self, **kwargs):
         """
-        Wrapper that automatically handles streaming for required models.
+        Wrapper that automatically handles streaming for required models, and
+        retries against fallback api_base URLs when the primary provider is
+        unreachable (connection refused / timeout / Cloudflare 524).
         """
+        fallback_bases = get_settings().get("openai.api_base_fallbacks", []) or []
+        if not isinstance(fallback_bases, list):
+            fallback_bases = [b.strip() for b in str(fallback_bases).split(",") if b.strip()]
+        # Try the primary base (already set on litellm/kwargs) first, then each
+        # fallback base. Only connection/timeout failures trigger a base switch;
+        # other errors (rate limit, bad request) propagate immediately.
+        bases_to_try = [None] + list(fallback_bases)  # None = use current/default base
+        last_exc = None
+        for idx, base in enumerate(bases_to_try):
+            attempt_kwargs = dict(kwargs)
+            if base:
+                attempt_kwargs["api_base"] = base
+            try:
+                return await self._get_completion_once(**attempt_kwargs)
+            except (openai.APIConnectionError, openai.APITimeoutError) as e:
+                last_exc = e
+                if idx < len(bases_to_try) - 1:
+                    next_base = bases_to_try[idx + 1]
+                    try:
+                        from pr_agent.servers.monitoring import record_llm_failure
+                        record_llm_failure("provider_fallback", attempt_kwargs.get("model", "unknown"))
+                    except Exception:
+                        pass
+                    get_logger().warning(
+                        f"Provider unreachable at base={base or 'primary'}; "
+                        f"falling back to base={next_base}: {e}"
+                    )
+                    continue
+                raise
+        # Unreachable, but keep the type checker honest.
+        if last_exc:
+            raise last_exc
+
+    async def _get_completion_once(self, **kwargs):
+        """Single completion attempt against the api_base currently in kwargs."""
         model = kwargs["model"]
         # FORK: route prefix-less Kimi/Claude/Minimax/GPT model names through the
         # configured OpenAI-compatible endpoint (CLIProxyAPI via Cloudflare Tunnel).

--- a/pr_agent/servers/monitoring.py
+++ b/pr_agent/servers/monitoring.py
@@ -58,7 +58,7 @@ WEBHOOK_FAILURES_TOTAL = Counter(
 def record_llm_failure(reason: str, model: str) -> None:
     """Record an LLM call failure.
 
-    reason: one of 'rate_limit', 'timeout', 'connect', 'api_error', 'schema_mismatch', 'unknown'
+    reason: one of 'rate_limit', 'timeout', 'connect', 'api_error', 'schema_mismatch', 'provider_fallback', 'unknown'
     model: the model name (e.g. 'kimi-k2.6')
     """
     LLM_FAILURES_TOTAL.labels(

--- a/tests/unittest/test_litellm_provider_fallback.py
+++ b/tests/unittest/test_litellm_provider_fallback.py
@@ -1,0 +1,84 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import openai
+import pytest
+
+from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
+
+
+def _handler():
+    """Build a handler without running the network-touching __init__."""
+    h = LiteLLMAIHandler.__new__(LiteLLMAIHandler)
+    h.streaming_required_models = []
+    return h
+
+
+@pytest.mark.asyncio
+async def test_no_fallback_configured_propagates_after_single_attempt():
+    """Empty api_base_fallbacks preserves original behavior: one attempt, then raise."""
+    h = _handler()
+    once = AsyncMock(side_effect=openai.APIConnectionError(request=MagicMock()))
+    with (
+        patch.object(h, "_get_completion_once", new=once),
+        patch("pr_agent.algo.ai_handlers.litellm_ai_handler.get_settings") as gs,
+    ):
+        gs.return_value.get.return_value = []
+        with pytest.raises(openai.APIConnectionError):
+            await h._get_completion(model="kimi-k2.6")
+    assert once.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_connect_failure_switches_to_fallback_base():
+    """A connection/timeout failure on the primary base retries on the fallback base."""
+    h = _handler()
+    bases = []
+
+    async def fake_once(**kwargs):
+        bases.append(kwargs.get("api_base"))
+        if kwargs.get("api_base") is None:  # primary base
+            raise openai.APITimeoutError(request=MagicMock())
+        return ("resp", "stop", MagicMock())
+
+    with (
+        patch.object(h, "_get_completion_once", new=fake_once),
+        patch("pr_agent.algo.ai_handlers.litellm_ai_handler.get_settings") as gs,
+    ):
+        gs.return_value.get.return_value = ["https://backup.example/v1"]
+        resp, finish, _ = await h._get_completion(model="kimi-k2.6")
+
+    assert resp == "resp"
+    assert bases == [None, "https://backup.example/v1"]
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_does_not_switch_base():
+    """Non-connectivity errors (rate limit) must propagate without trying fallbacks."""
+    h = _handler()
+    once = AsyncMock(
+        side_effect=openai.RateLimitError("rl", response=MagicMock(), body=None)
+    )
+    with (
+        patch.object(h, "_get_completion_once", new=once),
+        patch("pr_agent.algo.ai_handlers.litellm_ai_handler.get_settings") as gs,
+    ):
+        gs.return_value.get.return_value = ["https://backup.example/v1"]
+        with pytest.raises(openai.RateLimitError):
+            await h._get_completion(model="kimi-k2.6")
+    assert once.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_all_bases_exhausted_raises_last_error():
+    """If every base fails to connect, the last connection error propagates."""
+    h = _handler()
+    once = AsyncMock(side_effect=openai.APIConnectionError(request=MagicMock()))
+    with (
+        patch.object(h, "_get_completion_once", new=once),
+        patch("pr_agent.algo.ai_handlers.litellm_ai_handler.get_settings") as gs,
+    ):
+        gs.return_value.get.return_value = ["https://b1/v1", "https://b2/v1"]
+        with pytest.raises(openai.APIConnectionError):
+            await h._get_completion(model="kimi-k2.6")
+    # primary + 2 fallbacks = 3 attempts
+    assert once.await_count == 3


### PR DESCRIPTION
### **User description**
단일 provider(cliproxy) 장애 시 전체 모델이 같이 죽던 문제. connect/timeout 실패 시 fallback api_base로 재시도. 빈 기본값으로 backwards-compatible. 4 unit tests + 494 suite pass.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- provider 단위 `api_base` fallback 메커니즘 추가

- 연결/타임아웃 실패 시 대체 엔드포인트 순회 재시도

- rate limit 등 비연결 오류는 즉시 전파

- 하위 호환 기본값 모니터링 지표와 단위 테스트 추가


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["_get_completion"] -- "실행" --> B["_get_completion_once"]
  B -- "연결/타임아웃 오류" --> C["api_base fallback 전환"]
  C -- "재시도" --> B
  B -- "성공 또는 기타 오류" --> D["결과 반환 또는 예외 전파"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>litellm_ai_handler.py</strong><dd><code>`api_base` fallback 및 재시도 래퍼 로직 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/ai_handlers/litellm_ai_handler.py

<ul><li><code>_get_completion</code>에 fallback 로직 추가<br> <li> <code>api_base_fallbacks</code> 설정을 순회하며 연결/타임아웃 오류 시 재시도<br> <li> 단일 시도 로직을 <code>_get_completion_once</code>로 분리<br> <li> fallback 발생 시 <code>record_llm_failure("provider_fallback")</code> 기록</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/.github/pull/248/files#diff-ea1acaa0907f3410665530fbc4cda2ab524de2772e0bbe10bad4648b8be35dfe">+38/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>monitoring.py</strong><dd><code>`provider_fallback` 모니터링 사유 문서화 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/servers/monitoring.py

- `record_llm_failure` 함수 주석에 `provider_fallback` 실패 사유 추가


</details>


  </td>
  <td><a href="https://github.com/jclee941/.github/pull/248/files#diff-43d6b125a02c98e63bf33b58f356ffb74496ddf23aa168b5183939019a494fca">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_litellm_provider_fallback.py</strong><dd><code>provider fallback 동작 검증 단위 테스트 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_litellm_provider_fallback.py

<ul><li>fallback 미설정 시 단일 시도 후 예외 전파 테스트<br> <li> 연결 실패 시 fallback 엔드포인트 전환 및 성공 테스트<br> <li> rate limit 오류 시 base 전환 없이 즉시 전파 테스트<br> <li> 전체 base 소진 시 마지막 연결 오류 전파 테스트</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/.github/pull/248/files#diff-210cac27e8fc8916ad6a41774bb71959119c79ef4c8796e898b02087b0159bb1">+84/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pr_agent.toml</strong><dd><code>`api_base_fallbacks` 설정 및 주석 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pr_agent.toml

<ul><li><code>[openai]</code> 섹션에 <code>api_base_fallbacks = []</code> 설정 추가<br> <li> provider 장애 시 대체 엔드포인트 순회 관련 주석 추가</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/.github/pull/248/files#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

