### PR TITLE
fix(automation): branch-to-pr uses GH_PAT so auto-merge fires

### DIFF
--- a/.github/workflows/01_branch-to-pr.yml
+++ b/.github/workflows/01_branch-to-pr.yml
@@ -104,7 +104,13 @@ jobs:
       - name: Open draft PR
         if: steps.meta.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use GH_PAT (falls back to GITHUB_TOKEN) so the created PR triggers
+          # downstream 'pull_request' workflows. PRs opened with the default
+          # GITHUB_TOKEN do NOT fire other workflows (GitHub's recursion guard),
+          # which left required checks (pr-checks, Gitleaks) never running and
+          # auto-merge permanently BLOCKED. With a PAT the checks run and
+          # auto-merge actually fires.
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           BRANCH: ${{ steps.meta.outputs.branch }}
           BASE: ${{ steps.meta.outputs.base }}
           ISSUE_NUM: ${{ steps.meta.outputs.issue_number }}


### PR DESCRIPTION
### **User description**
ROOT CAUSE 수정: branch-to-pr가 GITHUB_TOKEN으로 PR 생성 → GitHub recursion guard로 required checks 미발화 → auto-merge 영구 BLOCKED. GH_PAT로 변경하면 checks 발화 + auto-merge 정상 작동. auto-deploy.yml과 동일 패턴.


___

### **PR Type**
Bug fix


___

### **Description**
- draft PR 생성 시 `GH_PAT` 사용

- `pull_request` 워크플로우 및 required checks 정상 발화

- auto-merge 영구 차단 상태 해결


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["branch-to-pr workflow"] -- "GH_PAT로 draft PR 생성" --> B["pull_request 이벤트 발화"]
  B -- "required checks 실행" --> C["pr-checks 및 Gitleaks"]
  C -- "체크 통과" --> D["auto-merge 정상 작동"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>01_branch-to-pr.yml</strong><dd><code>draft PR 생성 토큰을 GH_PAT로 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/01_branch-to-pr.yml

<ul><li><code>GH_TOKEN</code> 환경변수를 <code>secrets.GH_PAT || secrets.GITHUB_TOKEN</code>으로 변경<br> <li> <code>GITHUB_TOKEN</code> 재귀 방지로 인한 downstream 워크플로우 미트리거 문제 해결<br> <li> 필수 체크 실행 후 auto-merge 자동 활성화 지원</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/.github/pull/253/files#diff-2b8ecfd59845f64ef3ff1198ff2bcdabb8e782622b3b2b06c0402c4b45a08f16">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

