### PR TITLE
feat(automation): sync GH_PAT secret to all repos

### DIFF
--- a/scripts/cmd/sync-secrets/main.go
+++ b/scripts/cmd/sync-secrets/main.go
@@ -51,8 +51,14 @@ var publicRepos = []string{
 // secretsToSync names the env vars to sync. Each must be present in the
 // caller's environment; missing values fail loud rather than silently
 // erasing the downstream secret.
+//
+// GH_PAT is required so each repo's branch-to-pr.yml can open PRs with a
+// token that triggers downstream pull_request workflows (the default
+// GITHUB_TOKEN does not, which keeps required checks from running and
+// blocks auto-merge).
 var secretsToSync = []string{
 	"CLIPROXY_API_KEY",
+	"GH_PAT",
 }
 
 type result struct {


### PR DESCRIPTION
### **User description**
branch-to-pr GH_PAT fix가 작동하려면 각 레포에 GH_PAT secret 필요. jclee941은 User 계정이라 org-level 상속 불가. sync-secrets에 GH_PAT 추가. 14개 레포에 이미 live 설정됨.


___

### **PR Type**
Enhancement


___

### **Description**
- `sync-secrets`에 `GH_PAT` 시크릿 동기화 로직 추가

- `branch-to-pr` 자동 머지 차단 원인 해결

- 14개 레포 수동 적용 완료 및 코드화


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GH_PAT 환경 변수"] --> B["sync-secrets"]
  B -- "동기화" --> C["downstream 레포"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go`</strong><dd><code>`secretsToSync`에 `GH_PAT` 추가 및 주석 작성</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`scripts/cmd/sync-secrets/main.go`

<ul><li><code>secretsToSync</code> 슬라이스에 <code>"GH_PAT"</code> 항목 추가<br> <li> <code>GH_PAT</code> 필요성을 설명하는 주석 추가 (<code>GITHUB_TOKEN</code>이 <code>pull_request</code> 워크플로우를 트리거하지 못해 자동 <br>머지가 차단되는 문제 해결)</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

