### PR TITLE
fix(ci): use users/ endpoint for jclee941 and fix checkout ordering

### DIFF
--- a/.github/workflows/16_stale-repo-identifier.yml
+++ b/.github/workflows/16_stale-repo-identifier.yml
@@ -31,7 +31,7 @@ jobs:
           CUTOFF=$(date -u -d '90 days ago' +%Y-%m-%dT%H:%M:%SZ)
           STALE_REPOS=""
 
-          REPOS=$(gh api orgs/jclee941/repos --paginate --jq '.[] | select(.archived == false) | .name' 2>/dev/null | sort)
+          REPOS=$(gh api users/jclee941/repos --paginate --jq '.[] | select(.archived == false) | .name' 2>/dev/null | sort)
           if [ -z "$REPOS" ]; then
             echo "warning: could not fetch repo list from org"
             exit 0

--- a/.github/workflows/17_pr-stale-bot.yml
+++ b/.github/workflows/17_pr-stale-bot.yml
@@ -32,7 +32,7 @@ jobs:
           CUTOFF=$(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ)
           STALE_PRS=""
 
-          REPOS=$(gh api orgs/jclee941/repos --paginate --jq '.[] | select(.archived == false) | .name' 2>/dev/null | sort)
+          REPOS=$(gh api users/jclee941/repos --paginate --jq '.[] | select(.archived == false) | .name' 2>/dev/null | sort)
           if [ -z "$REPOS" ]; then
             echo "warning: could not fetch repo list from org"
             exit 0

--- a/.github/workflows/22_template-sync.yml
+++ b/.github/workflows/22_template-sync.yml
@@ -31,7 +31,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eu
-          repos=$(gh api orgs/jclee941/repos --paginate \
+          repos=$(gh api users/jclee941/repos --paginate \
             --jq '.[] | select(.archived == false and .name != ".github") | .name' \
             | sort | uniq | jq -R . | jq -s -c .)
           echo "repos=$repos" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/29_downstream-health-check.yml
+++ b/.github/workflows/29_downstream-health-check.yml
@@ -29,18 +29,20 @@ jobs:
         uses: step-security/harden-runner@v2
         with:
           egress-policy: audit
-      - name: Checkout repository inventory
-        uses: actions/checkout@v6
-        with:
-          repository: jclee941/.github
-          path: .github-inventory
-
+      # Default-path checkout MUST come first: actions/checkout cleans the
+      # workspace root, which would wipe a previously-checked-out subdir.
       - name: Checkout local actions
         uses: actions/checkout@v6
         with:
           repository: jclee941/.github
           ref: master
           fetch-depth: 1
+
+      - name: Checkout repository inventory
+        uses: actions/checkout@v6
+        with:
+          repository: jclee941/.github
+          path: .github-inventory
 
       - name: Check latest workflow runs across all repos
         id: health

--- a/.github/workflows/31_repo-health.yml
+++ b/.github/workflows/31_repo-health.yml
@@ -32,7 +32,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eu
-          repos=$(gh api orgs/jclee941/repos --paginate \
+          repos=$(gh api users/jclee941/repos --paginate \
             --jq '.[] | select(.archived == false) | .name' \
             | sort | uniq | jq -R . | jq -s -c .)
           echo "repos=$repos" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/32_org-health-report.yml
+++ b/.github/workflows/32_org-health-report.yml
@@ -35,7 +35,7 @@ jobs:
 
           CUTOFF_30D=$(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ)
 
-          REPOS=$(gh api orgs/jclee941/repos --paginate --jq '.[] | select(.archived == false) | .name' 2>/dev/null | sort)
+          REPOS=$(gh api users/jclee941/repos --paginate --jq '.[] | select(.archived == false) | .name' 2>/dev/null | sort)
           if [ -z "$REPOS" ]; then
             echo "warning: could not fetch repo list from org"
             exit 0

--- a/scripts/cmd/validate-naming/main.go
+++ b/scripts/cmd/validate-naming/main.go
@@ -44,6 +44,7 @@ func main() {
 		{"extraFiles have allowed extensions", v.extraFilesExtensions, nil},
 		{"required status checks match workflow check-run names", v.requiredStatusChecksMatchWorkflowContexts, nil},
 		{"notify-on-failure jobs checkout local actions first", v.notifyOnFailureRequiresCheckout, nil},
+		{"workflows query users/ not orgs/ for jclee941", v.noOrgEndpointForUserAccount, nil},
 	}
 
 	failed := 0
@@ -769,6 +770,41 @@ func (v *validator) notifyOnFailureRequiresCheckout() error {
 
 	if len(offenders) > 0 {
 		return fmt.Errorf("jobs use ./.github/actions/notify-on-failure without a prior default-path checkout: %s", strings.Join(offenders, "; "))
+	}
+	return nil
+}
+
+// noOrgEndpointForUserAccount guards against a recurring bug: jclee941 is a
+// USER account, not an organization, so `gh api orgs/jclee941/...` returns 404
+// and silently (2>/dev/null) yields empty repo lists or hard-fails matrix jobs.
+// All repo discovery must use the users/ endpoint.
+func (v *validator) noOrgEndpointForUserAccount() error {
+	dirs := []string{
+		filepath.Join(v.rootDir, ".github", "workflows"),
+		filepath.Join(v.rootDir, ".github", "workflows", "security"),
+	}
+	var offenders []string
+	for _, d := range dirs {
+		entries, err := os.ReadDir(d)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() || !(strings.HasSuffix(e.Name(), ".yml") || strings.HasSuffix(e.Name(), ".yaml")) {
+				continue
+			}
+			p := filepath.Join(d, e.Name())
+			b, err := os.ReadFile(p)
+			if err != nil {
+				return fmt.Errorf("read workflow %s: %w", p, err)
+			}
+			if strings.Contains(string(b), "orgs/jclee941") {
+				offenders = append(offenders, e.Name())
+			}
+		}
+	}
+	if len(offenders) > 0 {
+		return fmt.Errorf("workflows query the orgs/ endpoint for the jclee941 USER account (use users/jclee941): %s", strings.Join(offenders, ", "))
 	}
 	return nil
 }

--- a/scripts/cmd/validate-naming/main_test.go
+++ b/scripts/cmd/validate-naming/main_test.go
@@ -114,3 +114,33 @@ func TestNotifyOnFailureRequiresCheckoutRepoClean(t *testing.T) {
 		t.Fatalf("repo should satisfy notify-on-failure checkout invariant: %v", err)
 	}
 }
+
+func TestNoOrgEndpointForUserAccountDetectsOffender(t *testing.T) {
+	tmpDir := t.TempDir()
+	dir := filepath.Join(tmpDir, ".github", "workflows")
+	os.MkdirAll(dir, 0o755)
+	bad := "jobs:\n  x:\n    steps:\n      - run: gh api orgs/jclee941/repos\n"
+	os.WriteFile(filepath.Join(dir, "99_bad.yml"), []byte(bad), 0o644)
+
+	v := &validator{rootDir: tmpDir}
+	if err := v.noOrgEndpointForUserAccount(); err == nil {
+		t.Fatal("expected orgs/jclee941 usage to be flagged")
+	}
+
+	good := "jobs:\n  x:\n    steps:\n      - run: gh api users/jclee941/repos\n"
+	os.WriteFile(filepath.Join(dir, "99_bad.yml"), []byte(good), 0o644)
+	if err := v.noOrgEndpointForUserAccount(); err != nil {
+		t.Fatalf("users/jclee941 should pass, got: %v", err)
+	}
+}
+
+func TestNoOrgEndpointForUserAccountRepoClean(t *testing.T) {
+	rootDir, err := findRepoRoot()
+	if err != nil {
+		t.Fatalf("find repo root: %v", err)
+	}
+	v := &validator{rootDir: rootDir}
+	if err := v.noOrgEndpointForUserAccount(); err != nil {
+		t.Fatalf("repo should not use orgs/ endpoint for jclee941: %v", err)
+	}
+}


### PR DESCRIPTION
### **User description**
## 변경사항

<!-- 자동으로 생성된 PR입니다. 마크다운으로 변경 내용을 설명해주세요. -->

### 커밋 목록
- fix(ci): use users/ endpoint for jclee941 and fix checkout ordering (18b08223)

> Automated by jclee-bot (branch-to-pr.yml)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- jclee941 계정 조회를 users/ 엔드포인트로 변경

- 다운스트림 헬스 체크 체크아웃 순서 교정

- orgs/jclee941 사용 방지 검증 로직 추가

- 신규 검증 로직 단위 테스트 추가


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["orgs/jclee941 404 오류"] --> B["users/jclee941 정상 조회"]
  C["path 체크아웃 선행"] --> D["기본 경로 체크아웃 선행"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>main.go</strong><dd><code>jclee941 계정에 orgs/ 대신 users/ 사용 검증 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/.github/pull/301/files#diff-0cb0b30a10c4bf31dc72ecfd994c6f01adeed3bbb389fc7a1444b8e324e463f8">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>main_test.go</strong><dd><code>orgs/ 엔드포인트 검증 로직 단위 테스트 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/.github/pull/301/files#diff-7b8104cf8007170862c8016f83d9c8d6cfc3a33a0e190f620a32ab1d822b8243">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>16_stale-repo-identifier.yml</strong><dd><code>비활성 저장소 식별 엔드포인트를 users/로 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/.github/pull/301/files#diff-6b156af0cb54f4fbeb726f099f7dec037945521aced99cd1950f168ac78ad92a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>17_pr-stale-bot.yml</strong><dd><code>오래된 PR 봇 엔드포인트를 users/로 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/.github/pull/301/files#diff-1f91584ea28191327280da228ea1bc3fbb34ba9cb53389259a70c414cf64104f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>22_template-sync.yml</strong><dd><code>템플릿 동기화 엔드포인트를 users/로 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/.github/pull/301/files#diff-dd74f1bf172e34cbe2533aed59e8fcb404b31ea69fa4a4073d2c40b22b5faa99">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>29_downstream-health-check.yml</strong><dd><code>체크아웃 순서 교정으로 인벤토리 파일 보호</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/.github/pull/301/files#diff-0a2d1fa5e4f41ad7db3bbc643780738a3f440dc3f1b0731eb925db7fd7369f9b">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>31_repo-health.yml</strong><dd><code>저장소 건강도 조회 엔드포인트를 users/로 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/.github/pull/301/files#diff-9d1850dca91589c30d83f90beb7a4feda64355e2432672d0509171046ecc2d18">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>32_org-health-report.yml</strong><dd><code>조직 건강 보고서 엔드포인트를 users/로 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/.github/pull/301/files#diff-c9745bcdeaca08d38afff84612a46fcc2ba2e49fc9813f1d76e0f3db13b8f5dd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

