### PR TITLE
fix(ci): tolerate missing workflows in downstream health check

### DIFF
--- a/.github/workflows/29_downstream-health-check.yml
+++ b/.github/workflows/29_downstream-health-check.yml
@@ -58,7 +58,10 @@ jobs:
           for REPO in $REPOS; do
             FULL="jclee941/$REPO"
             for WF in "${WORKFLOWS[@]}"; do
-              LATEST=$(gh run list -R "$FULL" --workflow "$WF" --limit 1 --json conclusion,status,createdAt --jq '.[0]')
+              # Tolerate repos/workflows that don't exist: gh exits non-zero
+              # ("could not find any workflows named ...") which would abort the
+              # step under bash -e. Fall back to empty and skip via the check below.
+              LATEST=$(gh run list -R "$FULL" --workflow "$WF" --limit 1 --json conclusion,status,createdAt --jq '.[0]' 2>/dev/null || true)
               if [ -z "$LATEST" ] || [ "$LATEST" = "[]" ]; then
                 continue
               fi


### PR DESCRIPTION
### **User description**
## 변경사항

<!-- 자동으로 생성된 PR입니다. 마크다운으로 변경 내용을 설명해주세요. -->

### 커밋 목록
- fix(ci): tolerate missing workflows in downstream health check (ef8e2446)

> Automated by jclee-bot (branch-to-pr.yml)


___

### **PR Type**
Bug fix


___

### **Description**
- CI 워크플로우에서 `gh run list` 명령이 존재하지 않는 워크플로우 대해 非零 종료 코드를 반환하여 `bash -e`环境下에서 스크립트가 중단되는 문제 수정

- `2>/dev/null || true` 추가하여 에러를 무시하고 기존 빈 결과 처리 로직으로 정상적으로 건너뛸 수 있도록 변경


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gh run list"] --> B{워크플로우 존재?}
  B -->|존재함| C["정상 실행"]
  B -->|존재하지 않음| D["2>/dev/null || true"]
  D --> E["빈 결과로 처리"]
  E --> F["continue"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>29_downstream-health-check.yml</strong><dd><code>다운스트림 헬스체크 워크플로우 오류 허용</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/29_downstream-health-check.yml

<ul><li><code>gh run list</code> 명령에 <code>2>/dev/null || true</code> 추가<br> <li> 존재하지 않는 워크플로우/레포 시 에러 무시 및 빈 결과 처리 허용<br> <li> 왜 해당 수정이 필요한지 설명하는 주석 추가</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/.github/pull/305/files#diff-0a2d1fa5e4f41ad7db3bbc643780738a3f440dc3f1b0731eb925db7fd7369f9b">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

