### PR TITLE
fix(ci): make README Generator push idempotent and auto-mergeable

### DIFF
--- a/.github/workflows/20_readme-gen.yml
+++ b/.github/workflows/20_readme-gen.yml
@@ -78,13 +78,22 @@ jobs:
           set -eu
           git config user.email "bot@jclee.me"
           git config user.name "github-bot"
-          git checkout -b bot/auto-readme-update
+          # Re-create the bot branch from the freshly generated state. Fetch the
+          # remote branch first (if it exists) so the lease is valid; checkout -B
+          # makes the operation idempotent across repeated runs (fixed branch name).
+          git fetch origin bot/auto-readme-update:refs/remotes/origin/bot/auto-readme-update || true
+          git checkout -B bot/auto-readme-update
           git add README.md
-          git commit -m "docs: auto-update README.md [skip ci]"
+          # No [skip ci]: the PR needs its required checks to run so auto-merge
+          # can be satisfied.
+          git commit -m "docs: auto-update README.md"
           gh auth setup-git
-          git push -u origin bot/auto-readme-update --force-with-lease
+          git push -u origin bot/auto-readme-update \
+            --force-with-lease=bot/auto-readme-update:refs/remotes/origin/bot/auto-readme-update
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GH_PAT (not GITHUB_TOKEN) so the pushed branch triggers PR checks and
+          # auto-merge can fire.
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Create or update PR
         if: steps.diff.outputs.changed == 'true'
@@ -101,7 +110,7 @@ jobs:
               --head bot/auto-readme-update
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
         if: steps.diff.outputs.changed == 'true'
@@ -110,7 +119,7 @@ jobs:
           pr_number=$(gh pr list --head bot/auto-readme-update --json number --jq '.[0].number')
           gh pr merge "$pr_number" --auto --squash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
       - name: Notify on failure
         if: failure()
         uses: ./.github/actions/notify-on-failure

--- a/tests/unittest/test_git_flow_workflows.py
+++ b/tests/unittest/test_git_flow_workflows.py
@@ -227,11 +227,36 @@ class TestReadmeGeneratorOwnRepo:
         )
 
     def test_single_commit_branch_block(self):
-        """Only ONE 'git checkout -b bot/auto-readme-update' may exist."""
+        """Exactly ONE idempotent bot/auto-readme-update branch block may exist."""
         text = read_workflow("readme-gen.yml")
-        assert text.count("git checkout -b bot/auto-readme-update") == 1, (
-            "20_readme-gen.yml has a duplicated commit/push block; "
-            "collapse it into a single idempotent push."
+        # checkout -B (not -b) so re-runs are idempotent against the fixed branch.
+        assert text.count("git checkout -B bot/auto-readme-update") == 1, (
+            "20_readme-gen.yml must have exactly one idempotent "
+            "'git checkout -B bot/auto-readme-update' block."
+        )
+        assert "git checkout -b bot/auto-readme-update" not in text, (
+            "20_readme-gen.yml uses non-idempotent 'checkout -b'; use 'checkout -B' "
+            "so repeated runs do not fail on the existing branch."
+        )
+
+    def test_push_is_idempotent_and_pat_authed(self):
+        """Push must fetch the remote branch first (valid lease) and use GH_PAT so
+        the pushed branch triggers PR checks / auto-merge. [skip ci] must be gone."""
+        text = read_workflow("readme-gen.yml")
+        assert "git fetch origin bot/auto-readme-update" in text, (
+            "push must fetch the remote bot branch first or --force-with-lease will "
+            "fail with 'stale info' on re-runs."
+        )
+        commit_lines = [ln for ln in text.splitlines() if "git commit -m" in ln]
+        assert commit_lines, "20_readme-gen.yml has no git commit line"
+        for ln in commit_lines:
+            assert "[skip ci]" not in ln, (
+                "README PR commit must not carry [skip ci]; required checks must run "
+                f"for auto-merge to be satisfiable: {ln.strip()}"
+            )
+        assert "secrets.GH_PAT" in text, (
+            "README Generator must use GH_PAT so the pushed branch triggers PR checks "
+            "and auto-merge can fire (GITHUB_TOKEN pushes do not trigger workflows)."
         )
 
     def test_run_blocks_use_set_eu(self):


### PR DESCRIPTION
### **User description**
Fixes README Generator's recurring 'stale info' push failure + the [skip ci]/GITHUB_TOKEN issue that left auto-merge PRs with 0 checks.

- fetch remote bot branch first + checkout -B (idempotent, valid lease)
- explicit --force-with-lease=branch:remote-ref
- drop [skip ci] so required checks run
- GH_PAT so pushed branch triggers PR checks + auto-merge
- tests updated to lock the invariants


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- README Generator 푸시 실패 및 auto-merge 불가 수정

- fetch 후 checkout -B로 idempotent 재실행 보장

- skip ci 제거 및 GH_PAT으로 체크와 auto-merge 활성화

- idempotent 푸시와 PAT 인증 불변식 검증 테스트 추가


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["원격 브랜치 fetch"] --> B["checkout -B idempotent 체크아웃"]
  B --> C["skip ci 제거 커밋"]
  C --> D["GH_PAT 인증 force-with-lease 푸시"]
  D --> E["PR 필수 체크 실행"]
  E --> F["auto-merge 활성화"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>20_readme-gen.yml</strong><dd><code>README 생성 워크플로우 푸시 안정성 및 auto-merge 지원 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/20_readme-gen.yml

<ul><li>원격 <code>bot/auto-readme-update</code> 브랜치를 먼저 <code>fetch</code>한 뒤 <code>git checkout -B</code>로 체크아웃하여 재실행 <br>시에도 idempotent하게 동작하도록 변경<br> <li> 커밋 메시지에서 <code>[skip ci]</code>를 제거하여 PR의 필수 체크가 실행되도록 수정<br> <li> <code>git push</code> 시 명시적 <code>--force-with-lease=branch:remote-ref</code> 사용하여 stale info 오류 <br>방지<br> <li> <code>GH_TOKEN</code>을 <code>secrets.GH_PAT || secrets.GITHUB_TOKEN</code>으로 변경하여 푸시된 브랜치가 PR <br>워크플로우를 트리거하고 auto-merge가 동작하도록 수정</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/.github/pull/311/files#diff-3151312623e64c1035ee16621695ce8cf19800d6f70cb01f238c4d309d518c5a">+15/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_git_flow_workflows.py</strong><dd><code>README 생성기 CI 불변식 검증 테스트 강화</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_git_flow_workflows.py

<ul><li><code>git checkout -b</code> 대신 <code>git checkout -B</code>가 정확히 한 번 사용되는지 검증하도록 기존 테스트 수정<br> <li> 원격 브랜치 <code>fetch</code> 여부, <code>[skip ci]</code> 미포함, <code>secrets.GH_PAT</code> 사용 여부를 검증하는 <br><code>test_push_is_idempotent_and_pat_authed</code> 테스트 추가<br> <li> 기존 <code>test_single_commit_branch_block</code>의 설명 및 단언문을 idempotent 관점으로 업데이트</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/.github/pull/311/files#diff-03900f112756ff178320fd0d3491ea18d00921057e4e08169eaa3b979513be79">+29/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

