### PR TITLE
fix(ci): use plain --force for README bot branch push

### DIFF
--- a/.github/workflows/20_readme-gen.yml
+++ b/.github/workflows/20_readme-gen.yml
@@ -78,18 +78,19 @@ jobs:
           set -eu
           git config user.email "bot@jclee.me"
           git config user.name "github-bot"
-          # Re-create the bot branch from the freshly generated state. Fetch the
-          # remote branch first (if it exists) so the lease is valid; checkout -B
-          # makes the operation idempotent across repeated runs (fixed branch name).
-          git fetch origin bot/auto-readme-update:refs/remotes/origin/bot/auto-readme-update || true
+          # Re-create the bot branch from the freshly generated state.
+          # checkout -B is idempotent across repeated runs (fixed branch name),
+          # and --force below handles both the first run (no remote branch yet)
+          # and re-runs (existing remote branch) without a 'stale info' lease
+          # error. This is a bot-owned branch with the bot as sole writer, and
+          # the workflow concurrency group serialises runs, so --force is safe.
           git checkout -B bot/auto-readme-update
           git add README.md
           # No [skip ci]: the PR needs its required checks to run so auto-merge
           # can be satisfied.
           git commit -m "docs: auto-update README.md"
           gh auth setup-git
-          git push -u origin bot/auto-readme-update \
-            --force-with-lease=bot/auto-readme-update:refs/remotes/origin/bot/auto-readme-update
+          git push -u origin bot/auto-readme-update --force
         env:
           # GH_PAT (not GITHUB_TOKEN) so the pushed branch triggers PR checks and
           # auto-merge can fire.

--- a/tests/unittest/test_git_flow_workflows.py
+++ b/tests/unittest/test_git_flow_workflows.py
@@ -240,12 +240,21 @@ class TestReadmeGeneratorOwnRepo:
         )
 
     def test_push_is_idempotent_and_pat_authed(self):
-        """Push must fetch the remote branch first (valid lease) and use GH_PAT so
-        the pushed branch triggers PR checks / auto-merge. [skip ci] must be gone."""
+        """Push must be idempotent for both the first run (no remote branch yet)
+        and re-runs, and use GH_PAT so the pushed branch triggers PR checks /
+        auto-merge. [skip ci] must be gone."""
         text = read_workflow("readme-gen.yml")
-        assert "git fetch origin bot/auto-readme-update" in text, (
-            "push must fetch the remote bot branch first or --force-with-lease will "
-            "fail with 'stale info' on re-runs."
+        # checkout -B + plain --force works whether or not the remote branch
+        # exists. An explicit --force-with-lease=...:refs/remotes/... reference
+        # FAILS on the first run with 'cannot parse expected object name' because
+        # the remote-tracking ref does not exist yet.
+        assert "git push -u origin bot/auto-readme-update --force" in text, (
+            "push must use 'git push -u origin bot/auto-readme-update --force' so it "
+            "works on both first-run and re-run without a stale/missing lease."
+        )
+        assert "--force-with-lease" not in text, (
+            "--force-with-lease=...:refs/remotes/origin/... breaks on the first run "
+            "(remote-tracking ref absent). Use plain --force for the bot branch."
         )
         commit_lines = [ln for ln in text.splitlines() if "git commit -m" in ln]
         assert commit_lines, "20_readme-gen.yml has no git commit line"


### PR DESCRIPTION
### **User description**
## 변경사항

<!-- 자동으로 생성된 PR입니다. 마크다운으로 변경 내용을 설명해주세요. -->

### 커밋 목록
- fix(ci): use plain --force for README bot branch push (5192de4b)

> Automated by jclee-bot (branch-to-pr.yml)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 첫 실행 시 `--force-with-lease` 실패 문제 수정

- plain `--force`로 최초/재실행 멱등성 확보

- 불필요한 `git fetch` 제거 및 주석 갱신

- 테스트를 plain `--force` 사용 기준으로 갱신


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["기존: git fetch + --force-with-lease"] -- "첫 실행 실패" --> B["원격 추적 참조 없음"]
  C["변경: git checkout -B + plain --force"] -- "멱등 푸시" --> D["최초/재실행 성공"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>20_readme-gen.yml</strong><dd><code>README 봇 브랜치 푸시를 plain `--force`로 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/20_readme-gen.yml

<ul><li><code>git fetch origin bot/auto-readme-update</code> 명령어 제거<br> <li> <code>git push</code> 시 <code>--force-with-lease</code> 대신 plain <code>--force</code> 사용<br> <li> 봇 브랜치 단독 작성 및 워크플로우 동시성 제어로 인해 <code>--force</code>가 안전함을 설명하는 주석 추가</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/.github/pull/313/files#diff-3151312623e64c1035ee16621695ce8cf19800d6f70cb01f238c4d309d518c5a">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_git_flow_workflows.py</strong><dd><code>봇 브랜치 푸시 테스트를 plain `--force` 기준으로 갱신</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_git_flow_workflows.py

<ul><li><code>git fetch</code> 검증 제거 및 plain <code>--force</code> 사용 단언 추가<br> <li> <code>--force-with-lease</code> 포함 금지 단언 추가<br> <li> 테스트 docstring을 최초/재실행 멱등성에 맞게 수정</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/.github/pull/313/files#diff-03900f112756ff178320fd0d3491ea18d00921057e4e08169eaa3b979513be79">+14/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

