### PR TITLE
fix(ci): make Template Sync push idempotent (same stale-info bug as README)

### DIFF
--- a/.github/workflows/22_template-sync.yml
+++ b/.github/workflows/22_template-sync.yml
@@ -99,11 +99,14 @@ jobs:
           set -eu
           git config user.email "bot@jclee.me"
           git config user.name "github-bot"
-          git checkout -b bot/template-sync
+          # checkout -B + --force is idempotent across re-runs: the downstream
+          # bot/template-sync branch persists between runs, so 'checkout -b' +
+          # '--force-with-lease' fails with 'stale info'. The branch is bot-owned.
+          git checkout -B bot/template-sync
           git add CONTRIBUTING.md LICENSE
-          git commit -m "docs: sync CONTRIBUTING/LICENSE templates from jclee941/.github [skip ci]"
+          git commit -m "docs: sync CONTRIBUTING/LICENSE templates from jclee941/.github"
           gh auth setup-git
-          git push -u origin bot/template-sync --force-with-lease
+          git push -u origin bot/template-sync --force
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 

--- a/tests/unittest/test_git_flow_workflows.py
+++ b/tests/unittest/test_git_flow_workflows.py
@@ -385,3 +385,45 @@ class TestBranchNameAllowsBotBranches:
                 f"the bot PR can never pass 'Check Branch Name' / auto-merge. "
                 f"Add the 'bot' prefix to the allowed list."
             )
+
+
+# ---------------------------------------------------------------------------
+# Every fixed bot/* branch push must be idempotent across re-runs
+# ---------------------------------------------------------------------------
+
+class TestFixedBotBranchPushIsIdempotent:
+    """Workflows that push to a FIXED bot/* branch on a repo must use
+    'checkout -B' + plain '--force', never 'checkout -b' + '--force-with-lease'.
+    The latter fails on re-runs with 'stale info' (the branch persists) and on
+    first runs with 'cannot parse expected object name' (no remote-tracking ref).
+    """
+
+    # (workflow logical name, fixed branch it pushes to)
+    PUSHERS = [
+        ("readme-gen.yml", "bot/auto-readme-update"),
+        ("template-sync.yml", "bot/template-sync"),
+    ]
+
+    def test_no_checkout_dash_b_for_bot_branch(self):
+        for wf, branch in self.PUSHERS:
+            text = read_workflow(wf)
+            assert f"git checkout -b {branch}" not in text, (
+                f"{wf} uses non-idempotent 'git checkout -b {branch}'; use "
+                f"'git checkout -B {branch}' so re-runs do not fail."
+            )
+            assert f"git checkout -B {branch}" in text, (
+                f"{wf} must use 'git checkout -B {branch}'."
+            )
+
+    def test_no_force_with_lease_push_for_bot_branch(self):
+        for wf, branch in self.PUSHERS:
+            text = read_workflow(wf)
+            push_lines = [
+                ln for ln in text.splitlines()
+                if "git push" in ln or ln.strip().startswith("--force")
+            ]
+            for ln in push_lines:
+                assert "--force-with-lease" not in ln, (
+                    f"{wf} pushes the fixed branch {branch} with --force-with-lease, "
+                    f"which fails 'stale info' on re-runs: {ln.strip()}"
+                )


### PR DESCRIPTION
### **User description**
22_template-sync had the identical stale-info bug: checkout -b + --force-with-lease to the fixed downstream bot/template-sync branch fails on every re-run. Now checkout -B + --force.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Template Sync 워크플로우 푸시 멱등성 확보

- `git checkout -B` 및 `--force` 적용

- `[skip ci]` 제거로 다운스트림 체크 활성화

- 고정 `bot/*` 브랜치 푸시 검증 테스트 추가


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["git checkout -b + --force-with-lease"] -- "stale info 오류" --> B["재실행 실패"]
  C["git checkout -B + --force"] -- "멱등성 확보" --> D["재실행 성공"]
  E["TestFixedBotBranchPushIsIdempotent"] -- "규칙 검증" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>22_template-sync.yml</strong><dd><code>Template Sync 푸시 멱등성 확보 및 skip ci 제거</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/22_template-sync.yml

<ul><li><code>git checkout -b</code>를 <code>git checkout -B</code>로 변경<br> <li> <code>--force-with-lease</code>를 <code>--force</code>로 변경<br> <li> 커밋 메시지에서 <code>[skip ci]</code> 제거<br> <li> 멱등성 확보 목적의 주석 추가</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/.github/pull/328/files#diff-dd74f1bf172e34cbe2533aed59e8fcb404b31ea69fa4a4073d2c40b22b5faa99">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_git_flow_workflows.py</strong><dd><code>고정 bot 브랜치 푸시 멱등성 검증 테스트 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_git_flow_workflows.py

<ul><li><code>TestFixedBotBranchPushIsIdempotent</code> 테스트 클래스 신규 추가<br> <li> 고정 <code>bot/*</code> 브랜치 푸시 명령어 규칙 검증<br> <li> <code>readme-gen.yml</code> 및 <code>template-sync.yml</code> 대상 테스트</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/.github/pull/328/files#diff-03900f112756ff178320fd0d3491ea18d00921057e4e08169eaa3b979513be79">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

