### PR TITLE
fix(ci): strip hallucinated repo links from generated README

### DIFF
--- a/scripts/generate_readme.py
+++ b/scripts/generate_readme.py
@@ -17,6 +17,7 @@ import argparse
 import json
 import os
 import sys
+import re
 import urllib.request
 from pathlib import Path
 
@@ -24,6 +25,36 @@ API_BASE = os.environ.get("OPENAI_BASE_URL", "https://cliproxy.jclee.me/v1")
 API_KEY = os.environ.get("CLIPROXY_API_KEY", "")
 MODELS = ["minimax-m2.7", "gpt-5.5"]
 MAX_TOKENS = 4000
+
+# Repos that actually exist under github.com/jclee941. Links to any OTHER
+# jclee941 repo are LLM hallucinations (e.g. jclee941/CLIProxyAPI,
+# jclee941/github-bot) that 404 and fail the docs-sync link-check.
+_KNOWN_JCLEE_REPOS = {
+    ".github", "account", "blacklist", "bug", "hycu", "hycu_fsds",
+    "idle-outpost", "opencode", "propose", "pr-agent", "resume",
+    "safetywallet", "splunk", "terraform", "tmux", "youtube",
+    "automation-e2e-public",
+}
+
+
+def sanitize_links(text: str) -> str:
+    """Rewrite links to non-existent github.com/jclee941/<repo> URLs (LLM
+    hallucinations such as jclee941/CLIProxyAPI or jclee941/github-bot) to the
+    canonical source repo so they no longer 404 in the docs-sync link-check.
+
+    Operates on the bare URL, so it works for plain links, badges (nested
+    brackets), and raw URLs alike. Real jclee941 repos and any non-jclee941
+    link (e.g. qodo-ai/pr-agent) are left untouched."""
+    canonical = "https://github.com/jclee941/.github"
+    url_re = re.compile(r"https://github\.com/jclee941/([A-Za-z0-9._-]+)")
+
+    def _replace(m: re.Match) -> str:
+        repo = m.group(1)
+        if repo in _KNOWN_JCLEE_REPOS:
+            return m.group(0)  # real repo, keep the URL
+        return canonical  # hallucinated repo, rewrite to the canonical repo
+
+    return url_re.sub(_replace, text)
 
 
 def run_tree(repo_root: Path) -> str:
@@ -141,6 +172,9 @@ def generate_readme(repo_root: Path) -> str:
         "commands reference, and contribution guide. "
         "Be specific about what automation exists - list workflow names and tool names. "
         "Current README-gen models: minimax-m2.7 with fallback gpt-5.5 (via CLIProxyAPI). "
+        "Do NOT invent GitHub repository URLs: never link to non-existent repos such as "
+        "github.com/jclee941/CLIProxyAPI or github.com/jclee941/github-bot. For external "
+        "links use only qodo-ai/pr-agent, cliproxy.jclee.me, and bot.jclee.me. "
     )
 
     user_parts = [
@@ -181,7 +215,7 @@ def main() -> int:
     readme_path = repo_root / "README.md"
 
     print(f"Scanning {repo_root} ...")
-    content = generate_readme(repo_root)
+    content = sanitize_links(generate_readme(repo_root))
 
     if args.dry_run:
         print("\n--- GENERATED README ---\n")

--- a/tests/unittest/test_generate_readme.py
+++ b/tests/unittest/test_generate_readme.py
@@ -67,3 +67,32 @@ def test_module_imports_without_api_key(monkeypatch):
     mod = _load_module()
     assert callable(mod.generate_readme)
     assert callable(mod.read_key_files)
+
+
+def test_sanitize_links_strips_nonexistent_jclee_repos():
+    """The LLM hallucinates GitHub repo URLs (e.g. jclee941/CLIProxyAPI,
+    jclee941/github-bot) that 404 and fail docs-sync link-check. The generator
+    must neutralize links to non-existent jclee941 repos."""
+    mod = _load_module()
+    assert hasattr(mod, "sanitize_links"), (
+        "generate_readme.py must define sanitize_links(text) to remove "
+        "hallucinated/non-existent GitHub repo links before writing README."
+    )
+    md = (
+        "See [CLIProxyAPI](https://github.com/jclee941/CLIProxyAPI) and "
+        "[badge](https://github.com/jclee941/github-bot) plus the real "
+        "[upstream](https://github.com/qodo-ai/pr-agent) and [self](https://github.com/jclee941/.github)."
+    )
+    out = mod.sanitize_links(md)
+    # Hallucinated repo URLs must be gone (rewritten to the canonical repo).
+    assert "github.com/jclee941/CLIProxyAPI" not in out, out
+    assert "github.com/jclee941/github-bot" not in out, out
+    # Real/allowed links must survive untouched.
+    assert "github.com/qodo-ai/pr-agent" in out, out
+    assert "github.com/jclee941/.github" in out, out
+
+    # Badge form (nested brackets) must also be handled.
+    badge = "[![v](https://img.shields.io/badge/x.svg)](https://github.com/jclee941/github-bot)"
+    bout = mod.sanitize_links(badge)
+    assert "jclee941/github-bot" not in bout, bout
+    assert "img.shields.io" in bout, "badge image/label must be preserved"


### PR DESCRIPTION
### **User description**
## 변경사항

<!-- 자동으로 생성된 PR입니다. 마크다운으로 변경 내용을 설명해주세요. -->

### 커밋 목록
- fix(ci): strip hallucinated repo links from generated README (7b5424ec)

> Automated by jclee-bot (branch-to-pr.yml)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- LLM이 생성한 비존재 저장소 링크 정규화

- `sanitize_links()` 함수 추가 및 프롬프트 개선

- `README.md` 저장 전 링크 sanitize 적용

- `test_generate_readme.py`에 동작 검증 테스트 추가


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LLM README 생성"] --> B["sanitize_links()"]
  B --> C{"존재하는 저장소?"}
  C -- "예" --> D["원본 URL 유지"]
  C -- "아니오" --> E["github.com/jclee941/.github 로 재작성"]
  D --> F["README.md 저장"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate_readme.py</strong><dd><code>README 생성 스크립트에 허위 링크 제거 기능 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/generate_readme.py

<ul><li><code>re</code> 임포트 및 <code>_KNOWN_JCLEE_REPOS</code> 상수 집합 추가<br> <li> <code>sanitize_links()</code> 함수로 비존재 <code>github.com/jclee941/<repo></code> 링크를 <br><code>github.com/jclee941/.github</code>로 대체<br> <li> 시스템 프롬프트에 허위 저장소 URL 생성 금지 지시 추가<br> <li> <code>main()</code>에서 생성 결과를 <code>sanitize_links()</code>로 필터링 후 저장</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/.github/pull/337/files#diff-eceb85d77db99e6f8edbaf868feda4f82cd3fe00059f566189cfea9af00a2afa">+35/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_generate_readme.py</strong><dd><code>허위 저장소 링크 제거 로직 단위 테스트 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_generate_readme.py

<ul><li><code>test_sanitize_links_strips_nonexistent_jclee_repos()</code> 테스트 추가<br> <li> 일반 링크, 배지 형태, 실제/외부 링크 보존 여부 검증</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/.github/pull/337/files#diff-44b69686f2948dde8db85b95fb83341dc795cddafbefca95bf89318f5612ff7f">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

