### PR TITLE
fix(ci): also strip <thinking> tag variant in README normalizer

### DIFF
--- a/scripts/generate_readme.py
+++ b/scripts/generate_readme.py
@@ -48,8 +48,8 @@ def normalize_llm_readme_response(text: str) -> str:
     if not text:
         return text
     s = text
-    # 1. Remove <think>...</think> reasoning blocks.
-    s = re.sub(r"<think\b[^>]*>.*?</think>", "", s, flags=re.DOTALL | re.IGNORECASE)
+    # 1. Remove <think>/<thinking> reasoning blocks.
+    s = re.sub(r"<(think|thinking)\b[^>]*>.*?</\1>", "", s, flags=re.DOTALL | re.IGNORECASE)
     s = s.strip()
     # 2. Strip an opening code fence (```json / ```markdown). Handle BOTH closed
     #    fences and unclosed ones (truncated output that hit max_tokens).

--- a/tests/unittest/test_generate_readme.py
+++ b/tests/unittest/test_generate_readme.py
@@ -169,3 +169,12 @@ def test_sanitize_links_handles_http_and_www():
     assert "jclee941/github-bot" not in out, out
     assert "jclee941/CLIProxyAPI" not in out, out
     assert "jclee941/.github" in out, out
+
+
+def test_normalize_strips_thinking_variant():
+    """The <thinking>...</thinking> tag variant must also be stripped."""
+    mod = _load_module()
+    raw = "<thinking>\nplan\n</thinking>\n\n# Title\n\nbody"
+    out = mod.normalize_llm_readme_response(raw)
+    assert "<thinking>" not in out and "plan" not in out, out
+    assert out.lstrip().startswith("# Title"), out


### PR DESCRIPTION
### **User description**
## 변경사항

<!-- 자동으로 생성된 PR입니다. 마크다운으로 변경 내용을 설명해주세요. -->

### 커밋 목록
- fix(ci): also strip <thinking> tag variant in README normalizer (51848aa4)

> Automated by jclee-bot (branch-to-pr.yml)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- `<think>`와 `<thinking>` 추론 블록 모두 제거

- 정규식에 `\1` 역참조로 여닫는 태그 일치

- `<thinking>` 변형 제거 검증 테스트 추가


___

### Diagram Walkthrough


```mermaid
flowchart LR
  raw["Raw LLM Output"] --> norm["normalize_llm_readme_response"]
  norm -- "strips <think> and <thinking>" --> clean["Clean Markdown"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate_readme.py</strong><dd><code>`<thinking>` 태그 변형 제거 로직 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/generate_readme.py

<ul><li><code>normalize_llm_readme_response</code> 함수의 정규식 수정<br> <li> <code><think></code> 외에 <code><thinking></code> 태그 변형도 제거<br> <li> <code>\1</code> 역참조로 열고 닫는 태그 쌍 일치</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/.github/pull/358/files#diff-eceb85d77db99e6f8edbaf868feda4f82cd3fe00059f566189cfea9af00a2afa">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_generate_readme.py</strong><dd><code>`<thinking>` 제거 기능 단위 테스트 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_generate_readme.py

<ul><li><code>test_normalize_strips_thinking_variant</code> 테스트 함수 추가<br> <li> <code><thinking>...</thinking></code> 블록이 정상적으로 제거되는지 검증<br> <li> 제거 후 남은 본문이 올바른지 확인</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/.github/pull/358/files#diff-44b69686f2948dde8db85b95fb83341dc795cddafbefca95bf89318f5612ff7f">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

